### PR TITLE
Favor Map update syntax for speed improvement

### DIFF
--- a/lib/more_time.ex
+++ b/lib/more_time.ex
@@ -93,7 +93,7 @@ defmodule MoreTime do
         1,
         :hour
       ) do
-    Map.merge(dt, %{minute: 0, second: 0, microsecond: {0, 0}})
+    %{dt | minute: 0, second: 0, microsecond: {0, 0}}
   end
 
   def bucket(
@@ -139,7 +139,7 @@ defmodule MoreTime do
         1,
         :minute
       ) do
-    Map.merge(dt, %{second: 0, microsecond: {0, 0}})
+    %{dt | second: 0, microsecond: {0, 0}}
   end
 
   def bucket(
@@ -216,7 +216,7 @@ defmodule MoreTime do
           time_zone: _
         } = dt
       ) do
-    Map.merge(dt, %{hour: 0, minute: 0, second: 0, microsecond: {0, 0}})
+    %{dt | hour: 0, minute: 0, second: 0, microsecond: {0, 0}}
   end
 
   @doc """
@@ -244,7 +244,7 @@ defmodule MoreTime do
           time_zone: _
         } = dt
       ) do
-    Map.merge(dt, %{hour: 23, minute: 59, second: 59, microsecond: {999_999, 6}})
+    %{dt | hour: 23, minute: 59, second: 59, microsecond: {999_999, 6}}
   end
 
   @doc """
@@ -341,8 +341,7 @@ defmodule MoreTime do
           time_zone: _
         } = dt
       ) do
-    dt
-    |> Map.put(:day, 1)
+    %{dt | day: 1}
     |> beginning_of_day()
   end
 
@@ -405,8 +404,7 @@ defmodule MoreTime do
           time_zone: _
         } = dt
       ) do
-    dt
-    |> Map.merge(%{month: 1, day: 1})
+    %{dt | month: 1, day: 1}
     |> beginning_of_day()
   end
 
@@ -439,8 +437,7 @@ defmodule MoreTime do
     last_month_in_year = calendar.months_in_year(year)
     last_day_in_month = calendar.days_in_month(year, last_month_in_year)
 
-    dt
-    |> Map.merge(%{month: last_month_in_year, day: last_day_in_month})
+    %{dt | month: last_month_in_year, day: last_day_in_month}
     |> end_of_day()
   end
 


### PR DESCRIPTION
Merging multiple keys was showing > 1.2x slower than the map
update syntax via benchee. The update syntax is about the same
as `Map.put/3`.

```elixir
dt = DateTime.utc_now()

Benchee.run(%{
  "merge multiple" => fn ->
    Map.merge(dt, %{hour: 23, minute: 59, second: 59, microsecond: {999_999, 6}})
  end,
  "update syntax multiple" => fn ->
    %{dt | hour: 23, minute: 59, second: 59, microsecond: {999_999, 6}}
  end,
  "put" => fn ->
    Map.put(dt, :hour, 1)
  end,
  "update syntax singular" => fn ->
    %{dt | hour: 1}
  end
})
```

Results
```
Name                             ips        average  deviation         median         99th %
update syntax singular        3.79 M      264.00 ns ±15421.56%           0 ns        1000 ns
put                           3.60 M      277.52 ns ±11274.87%           0 ns        1000 ns
update syntax multiple        3.60 M      277.59 ns ±14598.29%           0 ns        1000 ns
merge multiple                2.92 M      342.94 ns ±11440.23%           0 ns        1000 ns

Comparison:
update syntax singular        3.79 M
put                           3.60 M - 1.05x slower +13.53 ns
update syntax multiple        3.60 M - 1.05x slower +13.59 ns
merge multiple                2.92 M - 1.30x slower +78.94 ns
```